### PR TITLE
Dockerfile: Remove Espeak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ RUN wget -qO - https://bootstrap.pypa.io/get-pip.py | python3 && \
     pip3 install -U pip
 
 RUN sudo apt-get update -y
-RUN sudo apt-get install espeak libclang1-3.4 python3-gi python3-dbus -y
 
 RUN pip3 install setuptools twine wheel munkres3 coverage pylint language-check pytest tox appdirs
 


### PR DESCRIPTION
In the Docker image, we install espeak. This package is not needed anymore, so we can remove it.
Fixes https://github.com/coala/rultor-python/issues/12